### PR TITLE
Fixed wrong output, created when cells can not be evenly divided betw…

### DIFF
--- a/src/examples/swe_mpi.cpp
+++ b/src/examples/swe_mpi.cpp
@@ -204,6 +204,7 @@ int main( int argc, char** argv ) {
 
   //! number of grid cells in x- and y-direction per process.
   int l_nXLocal, l_nYLocal;
+  int l_nXNormal, l_nYNormal;
 
   //! size of a single cell in x- and y-direction
   float l_dX, l_dY;
@@ -211,6 +212,8 @@ int main( int argc, char** argv ) {
   // compute local number of cells for each SWE_Block
   l_nXLocal = (l_blockPositionX < l_blocksX-1) ? l_nX/l_blocksX : l_nX - (l_blocksX-1)*(l_nX/l_blocksX);
   l_nYLocal = (l_blockPositionY < l_blocksY-1) ? l_nY/l_blocksY : l_nY - (l_blocksY-1)*(l_nY/l_blocksY);
+  l_nXNormal = l_nX/l_blocksX;
+  l_nYNormal = l_nY/l_blocksY;
 
   // compute the size of a single cell
   l_dX = (l_scenario.getBoundaryPos(BND_RIGHT) - l_scenario.getBoundaryPos(BND_LEFT) )/l_nX;
@@ -224,8 +227,8 @@ int main( int argc, char** argv ) {
   float l_originX, l_originY;
 
   // get the origin from the scenario
-  l_originX = l_scenario.getBoundaryPos(BND_LEFT) + l_blockPositionX*l_nXLocal*l_dX;;
-  l_originY = l_scenario.getBoundaryPos(BND_BOTTOM) + l_blockPositionY*l_nYLocal*l_dY;
+  l_originX = l_scenario.getBoundaryPos(BND_LEFT) + l_blockPositionX*l_nXNormal*l_dX;;
+  l_originY = l_scenario.getBoundaryPos(BND_BOTTOM) + l_blockPositionY*l_nYNormal*l_dY;
 
   // create a single wave propagation block
   auto l_waveBlock = SWE_Block::getBlockInstance(l_nXLocal, l_nYLocal, l_dX, l_dY);


### PR DESCRIPTION
SWE produces wrong output if blocks do not have uniform size.

Reason:
If the grid cannot be evenly distributed to all processors the last block in every
direction may get more cells than the rest. As the size of the local block is used to calculate
the position of the block, gaps may occur in the output-file (see example).

![wrong_output](https://user-images.githubusercontent.com/8849373/79394764-8d33b280-7f78-11ea-8b7e-ef6d52c88642.png)

Can be reproduced with:
mpirun -np 22  ./swe-mpi -x 1000 -y 1000 -c 20 -o ./output

Fixed this by using the size of the first block to calculate position.