### PR TITLE
Bugfix for CUDA implementation using multiple MPI processes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ if (MPI_FOUND)
     target_link_libraries(swe-mpi PRIVATE ${MPI_CXX_LIBRARIES})
     target_include_directories(swe-mpi PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
     target_include_directories(swe-mpi PRIVATE ${MPI_CXX_INCLUDE_DIRS})
+    add_definitions(-DUSEMPI)
 endif()
 
 if (OpenMP_FOUND AND ENABLE_OPENMP)

--- a/src/blocks/cuda/SWE_BlockCUDA.cu
+++ b/src/blocks/cuda/SWE_BlockCUDA.cu
@@ -179,12 +179,17 @@ void SWE_BlockCUDA::setBoundaryConditions() {
 #endif
   // Fill ghost layer corner cells
   kernelHdBufferEdges<<<1,1>>>(hd, nx, ny);
+  kernelHdBufferEdges<<<1,1>>>(hud, nx, ny);
+  kernelHdBufferEdges<<<1,1>>>(hvd, nx, ny);
 
 #ifdef DBG
  cout << "Call kernel to compute left/right boundaries " << flush << endl;
 #endif
 //   synchWaterHeightAfterWrite();
 //   synchDischargeAfterWrite();
+#ifdef USEMPI
+  synchGhostLayerAfterWrite();
+#endif
 
   if (boundary[BND_LEFT] == PASSIVE || boundary[BND_LEFT] == CONNECT) {
      // nothing to be done: 


### PR DESCRIPTION
1. USEMPI was not defined
-> No calls `synchCopyLayerBeforeRead()`
-> No memcpy Device->Host

2. No calls `synchGhostLayerAfterWrite`
-> No memcpy Host->Device.

Both issues are fixed.