### PR TITLE
Improve writing performance in NetCDFWriter

### DIFF
--- a/Source/Writers/NetCDFWriter.hpp
+++ b/Source/Writers/NetCDFWriter.hpp
@@ -29,6 +29,8 @@
 
 #pragma once
 
+#include <vector>
+#include "Tools/RealType.hpp"
 #include "Writer.hpp"
 
 namespace Writers {
@@ -40,6 +42,8 @@ namespace Writers {
     int dataFile_;
 
     int timeVar_, hVar_, huVar_, hvVar_, bVar_;
+
+    std::vector<RealType> temp;
 
     /** Flush after every x write operation? */
     unsigned int flush_;


### PR DESCRIPTION
Improve writing performance in NetCDFWriter by writing a single block instead of multiple ones.